### PR TITLE
checking if there is buffer to clean

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -128,7 +128,9 @@ class Module implements BootstrapListenerInterface
                         header('HTTP/1.0 500 Internal Server Error', true, 500);
                     }
 
-                    ob_clean();
+                    if (ob_get_length()) {
+                        ob_clean();
+                    }
                     $this->run->handleException($e->getParam('exception'));
                     break;
             }


### PR DESCRIPTION
Only executing `ob_clean` if there is a buffer to clean, otherwise
throws a “ob_clean(): failed to delete buffer. No buffer to delete”
notice, which gets trapped by whoops, informing me of the wrong error.
:)
